### PR TITLE
Update SOGo and SOPE versions to 5.10.0

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -12,9 +12,9 @@ archlinux_version=latest
 #https://aur.archlinux.org/packages/sogo/
 #https://aur.archlinux.org/packages/sope/
 #https://aur.archlinux.org/packages/libwbxml
-# target is 5.9.1
-sogo_sha=13a121fc563130d5d3f56a63914c9f8411b12eac
-sope_sha=55a184bdfdd64cc849e4b1baa47d07fd6d912b34
+# target is 5.10.0
+sogo_sha=39973cb34d15d32bc6a9d954a4888beca0497830
+sope_sha=3e08d28dc1d158dc3ea151b497ff9e2d4ba632c2
 # target is 0.11.8
 libwbxml_sha=68fd1910beae7e866815dbeafda7fbd76feab44d 
 # Prepare variables for later use


### PR DESCRIPTION
This pull request updates the SOGo and SOPE versions to 5.10.0. The previous versions were 5.9.1 and 55a184bdfdd64cc849e4b1baa47d07fd6d912b34 respectively. This update includes the necessary changes to the build-images.sh file.