### PR TITLE
fix: enable mod_expires, disable mod_reqtimeout for ActiveSync reliability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ldconfig \
     && sed -i 's/^Listen 80$/Listen 20001/' /etc/apache2/ports.conf \
     && a2dissite 000-default \
-    && a2enmod proxy proxy_http headers rewrite \
+    && a2enmod proxy proxy_http headers rewrite expires \
+    && a2dismod reqtimeout \
     && a2enconf SOGo \
     && mkdir -p /etc/supervisor.d \
     && useradd -r -d /var/lib/sogo sogo \


### PR DESCRIPTION
## Problem

Two Apache module issues introduced by the migration from Arch Linux to Debian Trixie (from SOGo 5.12.4 to 5.12.7):

### 1. `mod_reqtimeout` — random 404 on Microsoft ActiveSync (EAS)

On Debian, `mod_reqtimeout` is enabled by default **with an active configuration**:
```
RequestReadTimeout body=10,minrate=500
```

This kills EAS long-polling connections (Ping/FolderSync) from clients on slow or mobile networks: if the request body arrives at less than 500 bytes/s for 10 seconds, Apache silently aborts the connection. The behaviour is **random** (depends on network conditions), affecting some users but not others.

On the previous Arch-based build (≤5.12.4), `mod_reqtimeout` was compiled in but had no active configuration file, so this issue did not exist.

### 2. `mod_expires` — missing module, static resource caching broken

The `SOGo.conf` template uses:
```apache
<IfModule expires_module>
  ExpiresActive On
  ExpiresDefault "access plus 1 year"
</IfModule>
```

Without `mod_expires` enabled, this block is silently ignored and SOGo static resources (JS, CSS) are served without cache headers, causing unnecessary reloads.

## Fix

```dockerfile
&& a2enmod proxy proxy_http headers rewrite expires \
&& a2dismod reqtimeout \
```

- **`a2enmod expires`**: enables static resource caching as intended by SOGo's Apache config
- **`a2dismod reqtimeout`**: removes the body read timeout that randomly breaks EAS connections

Note: `retry=60 → retry=0` for the ActiveSync `ProxyPass` is fixed separately in [ns8-sogo](https://github.com/NethServer/ns8-sogo).