### PR TITLE
Enhance Apache configuration for reverse proxy support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,9 +116,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ldconfig \
     && sed -i 's/^Listen 80$/Listen 20001/' /etc/apache2/ports.conf \
     && a2dissite 000-default \
-    && a2enmod proxy proxy_http headers rewrite expires \
-    && a2dismod reqtimeout \
-    && a2enconf SOGo \
+    && a2enmod proxy proxy_http proxy_http2 proxy_balancer slotmem_shm headers rewrite reqtimeout authz_groupfile include userdir deflate expires remoteip \
+    && echo 'RemoteIPHeader X-Forwarded-For' > /etc/apache2/conf-available/remoteip.conf \
+    && echo 'RemoteIPInternalProxy 10.0.0.0/8' >> /etc/apache2/conf-available/remoteip.conf \
+    && a2enconf SOGo remoteip \
     && mkdir -p /etc/supervisor.d \
     && useradd -r -d /var/lib/sogo sogo \
     && mkdir -p /var/lib/sogo && chown sogo:sogo /var/lib/sogo \


### PR DESCRIPTION
Improve the Apache configuration to better support reverse proxy functionality by adding necessary modules and settings.

This was identified by comparing `sogo-server:5.12.4` (Arch Linux base) and `sogo-server:5.12.7` (Debian Trixie base) — the Debian image was missing several modules that were active in the Arch image.

## Apache modules (`a2enmod`)

| Module | Before | After | Reason |
|--------|--------|-------|--------|
| `proxy` | ✅ | ✅ | — |
| `proxy_http` | ✅ | ✅ | — |
| `proxy_http2` | ❌ | ✅ | Align with Arch, HTTP/2 support toward sogod |
| `proxy_balancer` | ❌ | ✅ | Align with Arch, load balancing for ActiveSync |
| `slotmem_shm` | ❌ | ✅ | Required by proxy_balancer |
| `headers` | ✅ | ✅ | — |
| `rewrite` | ✅ | ✅ | — |
| `reqtimeout` | ❌ (disabled) | ✅ | Align with Arch, protection against slow connections |
| `authz_groupfile` | ❌ | ✅ | Align with Arch |
| `include` | ❌ | ✅ | Align with Arch |
| `userdir` | ❌ | ✅ | Align with Arch |
| `deflate` | ❌ (disabled) | ✅ | gzip compression of responses |
| `expires` | ✅ | ✅ | Browser caching for static assets |
| `remoteip` | ❌ | ✅ | Real client IP behind a reverse proxy |

## Configuration (`a2enconf`)

| File | Content | Reason |
|------|---------|--------|
| `SOGo.conf` | `RedirectMatch ^/$ /SOGo/` uncommented | Redirect `/` → `/SOGo/` |
| `remoteip.conf` *(new)* | `RemoteIPHeader X-Forwarded-For` + `RemoteIPInternalProxy 10.0.0.0/8` | Propagate real client IP to logs and brute-force protection, following ns8-lamp pattern |